### PR TITLE
Fix for an exception caused by rubber ring on hosted server

### DIFF
--- a/fabric/src/main/java/net/satisfy/beachparty/fabric/core/compat/BeachpartyTrinket.java
+++ b/fabric/src/main/java/net/satisfy/beachparty/fabric/core/compat/BeachpartyTrinket.java
@@ -1,6 +1,9 @@
 package net.satisfy.beachparty.fabric.core.compat;
 
 import dev.emi.trinkets.api.*;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
@@ -141,7 +144,8 @@ public class BeachpartyTrinket {
             if (!(entity instanceof Player player)) return;
 
             if (player.isInWater()) {
-                if (player instanceof LocalPlayer && Minecraft.getInstance().options.keyJump.isDown()) {
+                
+                if (shouldSkipDueToJumpKeyPress(player)) {
                     return;
                 }
 
@@ -175,6 +179,18 @@ public class BeachpartyTrinket {
 
                 spawnWaterParticles(player, leftPos, rightPos);
             }
+        }
+        
+        private boolean shouldSkipDueToJumpKeyPress(Player player) {
+            if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
+                return checkJumpKeyOnClient(player);
+            }
+            return false;
+        }
+
+        @Environment(EnvType.CLIENT)
+        private boolean checkJumpKeyOnClient(Player player) {
+            return player instanceof LocalPlayer && Minecraft.getInstance().options.keyJump.isDown();
         }
 
         private void spawnWaterParticles(Player player, Vec3 leftPos, Vec3 rightPos) {


### PR DESCRIPTION
net.minecraft.class_148: Ticking player
        at net.minecraft.class_3222.method_14226(class_3222.java:574) ~[server-intermediary.jar:?]
        at net.minecraft.class_3244.method_18784(class_3244.java:269) ~[server-intermediary.jar:?]
        at net.minecraft.class_2535.method_10754(class_2535.java:259) ~[server-intermediary.jar:?]
        at net.minecraft.class_3242.method_14357(class_3242.java:172) ~[server-intermediary.jar:?]
        at net.minecraft.server.MinecraftServer.method_3813(MinecraftServer.java:908) ~[server-intermediary.jar:?]
        at net.minecraft.class_3176.method_3813(class_3176.java:283) ~[server-intermediary.jar:?]
        at net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:824) ~[server-intermediary.jar:?]
        at net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:671) ~[server-intermediary.jar:?]
        at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:265) ~[server-intermediary.jar:?]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
Caused by: java.lang.NoClassDefFoundError: net/minecraft/class_746
        at net.satisfy.beachparty.fabric.core.compat.BeachpartyTrinket$RubberRingTrinket.tick(BeachpartyTrinket.java:144) ~[letsdo-beachparty-fabric-2.0.0.jar:?]
        at net.minecraft.class_1309.md4fd6d4$trinkets$lambda$tick$2$24(class_1309.java:15048) ~[server-intermediary.jar:?]
        at dev.emi.trinkets.api.LivingEntityTrinketComponent.forEach(LivingEntityTrinketComponent.java:362) ~[trinkets-3.7.2.jar:?]
        at net.minecraft.class_1309.md4fd6d4$trinkets$lambda$tick$3$23(class_1309.java:14993) ~[server-intermediary.jar:?]
        at java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
        at net.minecraft.class_1309.handler$ilb020$trinkets$tick(class_1309.java:14990) ~[server-intermediary.jar:?]
        at net.minecraft.class_1309.method_5773(class_1309.java:2499) ~[server-intermediary.jar:?]
        at net.minecraft.class_1657.method_5773(class_1657.java:283) ~[server-intermediary.jar:?]
        at net.minecraft.class_3222.method_14226(class_3222.java:510) ~[server-intermediary.jar:?]
        ... 9 more
Caused by: java.lang.ClassNotFoundException: net.minecraft.class_746
        at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[?:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.loadClass(KnotClassDelegate.java:226) ~[fabric-loader-0.16.10.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:119) ~[fabric-loader-0.16.10.jar:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
        at net.satisfy.beachparty.fabric.core.compat.BeachpartyTrinket$RubberRingTrinket.tick(BeachpartyTrinket.java:144) ~[letsdo-beachparty-fabric-2.0.0.jar:?]
        at net.minecraft.class_1309.md4fd6d4$trinkets$lambda$tick$2$24(class_1309.java:15048) ~[server-intermediary.jar:?]
        at dev.emi.trinkets.api.LivingEntityTrinketComponent.forEach(LivingEntityTrinketComponent.java:362) ~[trinkets-3.7.2.jar:?]
        at net.minecraft.class_1309.md4fd6d4$trinkets$lambda$tick$3$23(class_1309.java:14993) ~[server-intermediary.jar:?]
        at java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
        at net.minecraft.class_1309.handler$ilb020$trinkets$tick(class_1309.java:14990) ~[server-intermediary.jar:?]
        at net.minecraft.class_1309.method_5773(class_1309.java:2499) ~[server-intermediary.jar:?]
        at net.minecraft.class_1657.method_5773(class_1657.java:283) ~[server-intermediary.jar:?]
        at net.minecraft.class_3222.method_14226(class_3222.java:510) ~[server-intermediary.jar:?]
        ... 9 more